### PR TITLE
Fix: ta bort felaktig import av SearchFormValues

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/router";
 
-import SearchForm, { type SearchFormValues } from "../components/SearchForm";
+import SearchForm from "../components/SearchForm";
 import ResultsList, { type Train } from "../components/ResultsList";
 import { searchRoutes } from "../utils/searchRoutes";
 import SeoHead from "../components/SeoHead";


### PR DESCRIPTION
Denna PR rättar ett kompileringsfel genom att ta bort en felaktig import av SearchFormValues från SearchForm.tsx. Ingen layout eller funktionalitet ändras.